### PR TITLE
entkit: run ent codegen first

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -282,6 +282,10 @@ func SkipGoModTidy() GeneratorOption {
 func GeneratorHook(ex *Extension) gen.Hook {
 	return func(next gen.Generator) gen.Generator {
 		return gen.GenerateFunc(func(g *gen.Graph) error {
+			// Run ent codegen first to ensure working against an updated schema.
+			if err := next.Generate(g); err != nil {
+				return err
+			}
 
 			var tracked = false
 
@@ -307,7 +311,7 @@ func GeneratorHook(ex *Extension) gen.Hook {
 				}
 			}
 
-			return next.Generate(g)
+			return nil
 		})
 	}
 }


### PR DESCRIPTION
This ensures one does not have to run `go generate` twice after a schema change to have entkit reflect the latest changes. Especially useful if using `IgnoreUncommittedChanges()` option.