### PR TITLE
entkit/templates: ensure importing correct field types

### DIFF
--- a/templates/search_query_apply.tmpl
+++ b/templates/search_query_apply.tmpl
@@ -6,8 +6,10 @@
 {{- /* Add the base header for the generated file */ -}}
 
 {{ template "header" $ }}
-
-import "context"
+import (
+	"context"
+	{{ range $.Nodes }}{{ template "import/types" . }}{{ end }}
+)
 
 {{ range $n := $.Nodes }}
 	{{- $builder := print $n.Name "WhereInput" }}


### PR DESCRIPTION
If you use custom field types (`GoType()`) ensure to import those types in the templates so goimports does not import a wrong package.